### PR TITLE
Fix EOF misclassification in HDR prescan near stream tail

### DIFF
--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -620,6 +620,12 @@ class Processor(QtCore.QObject):
         """Discard up to ``count`` decoded frames without restarting the reader."""
 
         def _at_known_eof() -> bool:
+            reader_eof = getattr(cap, "_at_known_eof", None)
+            if callable(reader_eof):
+                try:
+                    return bool(reader_eof())
+                except Exception:
+                    pass
             try:
                 total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
             except Exception:
@@ -631,6 +637,8 @@ class Processor(QtCore.QObject):
             except Exception:
                 pos = 0
             if bool(getattr(cap, "_is_hdr_pipe", False)):
+                if not bool(getattr(cap, "_total_is_exact", False)):
+                    return False
                 # FfmpegPipeReader reports the last emitted frame index.
                 return pos >= total - 1
             # OpenCV usually reports the next frame index.

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -654,7 +654,7 @@ class Processor(QtCore.QObject):
                 raise
             if not grabbed:
                 startup_exc = getattr(cap, "_last_startup_error", None)
-                if startup_exc is not None and not _at_known_eof():
+                if startup_exc is not None:
                     self._status(
                         f"Pre-scan skip failed: {startup_exc}",
                         key="prescan_skip_error",
@@ -947,6 +947,14 @@ class Processor(QtCore.QObject):
                         break
                     ok, frame = cap.retrieve()
                     if not ok or frame is None:
+                        startup_exc = getattr(cap, "_last_startup_error", None)
+                        if startup_exc is not None:
+                            self._status(
+                                f"Pre-scan read failed: {startup_exc}",
+                                key="prescan_skip_error",
+                                interval=0.5,
+                            )
+                            raise RuntimeError("Pre-scan reader failed during retrieve") from startup_exc
                         target_skip = min(
                             max(0, stride - 1),
                             max(0, total_frames - i - 1),

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -618,14 +618,34 @@ class Processor(QtCore.QObject):
 
     def _prescan_skip_forward(self, cap, count: int) -> int:
         """Discard up to ``count`` decoded frames without restarting the reader."""
+
+        def _at_known_eof() -> bool:
+            try:
+                total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+            except Exception:
+                total = 0
+            if total <= 0:
+                return False
+            try:
+                pos = int(cap.get(cv2.CAP_PROP_POS_FRAMES) or 0)
+            except Exception:
+                pos = 0
+            if bool(getattr(cap, "_is_hdr_pipe", False)):
+                # FfmpegPipeReader reports the last emitted frame index.
+                return pos >= total - 1
+            # OpenCV usually reports the next frame index.
+            return pos >= total
+
         advanced = 0
         remaining = max(0, int(count))
         for _ in range(remaining):
-            if self._abort:
+            if self._abort or _at_known_eof():
                 break
             try:
                 grabbed = cap.grab()
             except Exception as exc:
+                if _at_known_eof():
+                    break
                 self._status(
                     f"Pre-scan skip failed: {exc}",
                     key="prescan_skip_error",
@@ -634,7 +654,7 @@ class Processor(QtCore.QObject):
                 raise
             if not grabbed:
                 startup_exc = getattr(cap, "_last_startup_error", None)
-                if startup_exc is not None:
+                if startup_exc is not None and not _at_known_eof():
                     self._status(
                         f"Pre-scan skip failed: {startup_exc}",
                         key="prescan_skip_error",
@@ -927,10 +947,14 @@ class Processor(QtCore.QObject):
                         break
                     ok, frame = cap.retrieve()
                     if not ok or frame is None:
-                        skipped = self._prescan_skip_forward(cap, max(0, stride - 1))
-                        if skipped < max(0, stride - 1):
+                        target_skip = min(
+                            max(0, stride - 1),
+                            max(0, total_frames - i - 1),
+                        )
+                        skipped = self._prescan_skip_forward(cap, target_skip)
+                        if skipped < target_skip:
                             break
-                        i += stride
+                        i = i + 1 + skipped
                         continue
                     if self._hdr_preview_enabled():
                         self._hdr_preview_seek(i)
@@ -1110,10 +1134,14 @@ class Processor(QtCore.QObject):
                             self._emit_preview_bgr(vis)
                         except Exception:
                             pass
-                    skipped = self._prescan_skip_forward(cap, max(0, stride - 1))
-                    if skipped < max(0, stride - 1):
+                    target_skip = min(
+                        max(0, stride - 1),
+                        max(0, total_frames - idx - 1),
+                    )
+                    skipped = self._prescan_skip_forward(cap, target_skip)
+                    if skipped < target_skip:
                         break
-                    i += stride
+                    i = idx + 1 + skipped
                 if active:
                     s = max(0, start - pad)
                     e = total_frames - 1

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -944,6 +944,14 @@ class Processor(QtCore.QObject):
                             pass
                         continue
                     if not cap.grab():
+                        startup_exc = getattr(cap, "_last_startup_error", None)
+                        if startup_exc is not None:
+                            self._status(
+                                f"Pre-scan read failed: {startup_exc}",
+                                key="prescan_skip_error",
+                                interval=0.5,
+                            )
+                            raise RuntimeError("Pre-scan reader failed during grab") from startup_exc
                         break
                     ok, frame = cap.retrieve()
                     if not ok or frame is None:

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -7026,6 +7026,55 @@ class MainWindow(QtWidgets.QMainWindow):
         except Exception:
             pass
 
+    def eventFilter(self, watched, event):
+        try:
+            if (
+                event.type() == QtCore.QEvent.Type.Wheel
+                and bool(watched.property("_pc_no_wheel_value_edit"))
+            ):
+                self._scroll_parent_area(watched, event)
+                return True
+        except Exception:
+            pass
+        return super().eventFilter(watched, event)
+
+    def _mark_no_wheel_value_edit(self, widget: QtWidgets.QWidget):
+        watched = []
+        value_types = (
+            QtWidgets.QAbstractSpinBox,
+            QtWidgets.QComboBox,
+            QtWidgets.QAbstractSlider,
+        )
+        if isinstance(widget, value_types):
+            watched.append(widget)
+        for widget_type in value_types:
+            watched.extend(widget.findChildren(widget_type))
+
+        seen = set()
+        for child in watched:
+            ident = id(child)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            child.setProperty("_pc_no_wheel_value_edit", True)
+            child.installEventFilter(self)
+
+    def _scroll_parent_area(self, widget: QtWidgets.QWidget, event: QtGui.QWheelEvent):
+        parent = widget.parent()
+        while parent is not None and not isinstance(parent, QtWidgets.QScrollArea):
+            parent = parent.parent()
+        if parent is None:
+            return
+
+        bar = parent.verticalScrollBar()
+        pixel_delta = event.pixelDelta().y()
+        if pixel_delta:
+            delta = -pixel_delta
+        else:
+            delta = -int(event.angleDelta().y() / 120.0 * max(1, bar.singleStep() * 3))
+        if delta:
+            bar.setValue(bar.value() + delta)
+
     def _install_filter(self):
         # Build label->row index for settings filtering
         try:
@@ -7045,6 +7094,8 @@ class MainWindow(QtWidgets.QMainWindow):
                             fi = layout.itemAtPosition(i, 1)
                             if li and fi and li.widget() and fi.widget():
                                 self._param_rows.append((li.widget(), fi.widget()))
+            for _, field in getattr(self, "_param_rows", []):
+                self._mark_no_wheel_value_edit(field)
             if hasattr(self, "search_edit"):
                 self.search_edit.textChanged.connect(self._apply_filter)
         except Exception:

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -951,7 +951,27 @@ class Processor(QtCore.QObject):
                         except Exception:
                             pass
                         continue
-                    if not cap.grab():
+                    try:
+                        grabbed = cap.grab()
+                    except Exception as exc:
+                        at_known_eof = False
+                        reader_eof = getattr(cap, "_at_known_eof", None)
+                        if callable(reader_eof):
+                            try:
+                                at_known_eof = bool(reader_eof())
+                            except Exception:
+                                at_known_eof = False
+                        if at_known_eof:
+                            break
+                        startup_exc = getattr(cap, "_last_startup_error", None)
+                        detail = startup_exc if startup_exc is not None else exc
+                        self._status(
+                            f"Pre-scan read failed: {detail}",
+                            key="prescan_skip_error",
+                            interval=0.5,
+                        )
+                        raise RuntimeError("Pre-scan reader failed during grab") from exc
+                    if not grabbed:
                         startup_exc = getattr(cap, "_last_startup_error", None)
                         if startup_exc is not None:
                             self._status(

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -1153,6 +1153,7 @@ class FfmpegPipeReader:
         self._h = int(s.get("height") or 0)
         self._fps = _safe_fps(s.get("avg_frame_rate") or "0/1")
         self._nb = int(s.get("nb_frames") or 0)
+        self._total_is_exact = self._nb > 0
         self._src_pixfmt = _str_lower_nonempty(s.get("pix_fmt"))
         try:
             self._bits_per_raw_sample = int(s.get("bits_per_raw_sample") or 0)
@@ -1498,6 +1499,8 @@ class FfmpegPipeReader:
         self._start(0)
 
     def _known_total_frames(self) -> int:
+        if not bool(getattr(self, "_total_is_exact", False)):
+            return 0
         try:
             total = int(getattr(self, "_nb", 0) or getattr(self, "_total", 0) or 0)
         except (TypeError, ValueError):
@@ -2819,6 +2822,7 @@ class FfmpegPipeReader:
     def grab(self) -> bool:
         while True:
             if self._at_known_eof():
+                self._last_startup_error = None
                 return False
 
             try:
@@ -2939,6 +2943,7 @@ class FfmpegPipeReader:
         # attempt a one-time filter-chain fallback before giving up.
         if self._proc is not None and self._proc.poll() is not None:
             if self._at_known_eof():
+                self._last_startup_error = None
                 return False, None
             if not self.try_fallback_chain():
                 return False, None

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -1497,16 +1497,36 @@ class FfmpegPipeReader:
             return
         self._start(0)
 
+    def _known_total_frames(self) -> int:
+        try:
+            total = int(getattr(self, "_nb", 0) or getattr(self, "_total", 0) or 0)
+        except (TypeError, ValueError):
+            total = 0
+        return max(0, total)
+
+    def _next_frame_index(self) -> int:
+        try:
+            return max(0, int(getattr(self, "_pos", -1)) + 1)
+        except (TypeError, ValueError):
+            return 0
+
+    def _at_known_eof(self, next_idx: Optional[int] = None) -> bool:
+        total = self._known_total_frames()
+        if total <= 0:
+            return False
+        if next_idx is None:
+            next_idx = self._next_frame_index()
+        return int(next_idx) >= total
+
     def _ensure_started(self) -> bool:
         proc = self._proc
         if proc is not None and getattr(proc, "poll", lambda: 1)() is None:
             return True
         if proc is not None:
             self._stop()
-        try:
-            next_idx = max(0, int(getattr(self, "_pos", -1)) + 1)
-        except (TypeError, ValueError):
-            next_idx = 0
+        next_idx = self._next_frame_index()
+        if self._at_known_eof(next_idx):
+            return False
         try:
             self._start(next_idx)
         except Exception as exc:
@@ -1669,6 +1689,12 @@ class FfmpegPipeReader:
         Returns True if we switched chains; False if no further fallback exists.
         """
         if self._mode == "p010_passthrough":
+            return False
+        # A short read at or past the known frame count is normal end-of-stream,
+        # not evidence that the active filter chain failed. This matters for
+        # late pre-scan skips and deferred probes: strict LP must not turn EOF
+        # into a fatal "produced no frames" error.
+        if self._at_known_eof():
             return False
         if self._fallback_hops >= getattr(self, "_fallback_hops_max", 12):
             self._log.error("LP fallback exhausted after %s hops.", self._fallback_hops)
@@ -2792,12 +2818,15 @@ class FfmpegPipeReader:
 
     def grab(self) -> bool:
         while True:
+            if self._at_known_eof():
+                return False
+
             try:
                 started = self._ensure_started()
                 self._last_startup_error = None
             except Exception as exc:
                 self._last_startup_error = exc
-                if self._mode != "p010_passthrough":
+                if self._mode != "p010_passthrough" and not self._at_known_eof():
                     self._log.warning(
                         "HDR pipe startup failed during grab; trying fallback: %s",
                         exc,
@@ -2808,40 +2837,48 @@ class FfmpegPipeReader:
                 return False
 
             if not started or not self._proc or not self._proc.stdout:
-                if self._mode != "p010_passthrough" and self.try_fallback_chain():
+                if (
+                    self._mode != "p010_passthrough"
+                    and not self._at_known_eof()
+                    and self.try_fallback_chain()
+                ):
                     continue
                 return False
-            break
 
-        if self._pix_fmt in {"bgr24", "nv12", "p010le"}:
-            need = self._pipe_frame_bytes
-            buf = self._proc.stdout.read(need)
-            if not buf or len(buf) < need:
-                if self._mode != "p010_passthrough" and self.try_fallback_chain():
-                    return self.grab()
+            if self._pix_fmt in {"bgr24", "nv12", "p010le"}:
+                need = self._pipe_frame_bytes
+                buf = self._proc.stdout.read(need)
+                if not buf or len(buf) < need:
+                    # EOF/late-seek-empty is a normal false return. Only run
+                    # the expensive LP fallback ladder when the short read
+                    # occurs before the known end of the stream.
+                    if self._mode != "p010_passthrough" and not self._at_known_eof():
+                        if self.try_fallback_chain():
+                            continue
+                    return False
+                self._pipe_buf = buf
+                self._arr = None
+                self._pos += 1
+                return True
+
+            # Linear+python-tonemap path: read float32 RGB (planar G,B,R)
+            fbytes = self._frame_bytes_f32
+            buf = self._proc.stdout.read(fbytes)
+            if not buf or len(buf) < fbytes:
                 return False
-            self._pipe_buf = buf
-            self._arr = None
+            planar = np.frombuffer(buf, dtype=np.float32)
+            if planar.size != self._w * self._h * 3:
+                return False
+            planar = planar.reshape(3, self._h, self._w)
+            rgb = np.stack((planar[2], planar[0], planar[1]), axis=-1)
+            if getattr(self, "_transfer", "") == "arib-std-b67":
+                rgb_linear = _eotf_hlg(rgb)
+            else:
+                rgb_linear = _eotf_pq(rgb)
+            self._arr = rgb_linear
+            self._pipe_buf = None
             self._pos += 1
             return True
-        # Linear+python-tonemap path: read float32 RGB (planar G,B,R)
-        fbytes = self._frame_bytes_f32
-        buf = self._proc.stdout.read(fbytes)
-        if not buf or len(buf) < fbytes:
-            return False
-        planar = np.frombuffer(buf, dtype=np.float32)
-        if planar.size != self._w * self._h * 3:
-            return False
-        planar = planar.reshape(3, self._h, self._w)
-        rgb = np.stack((planar[2], planar[0], planar[1]), axis=-1)
-        if getattr(self, "_transfer", "") == "arib-std-b67":
-            rgb_linear = _eotf_hlg(rgb)
-        else:
-            rgb_linear = _eotf_pq(rgb)
-        self._arr = rgb_linear
-        self._pipe_buf = None
-        self._pos += 1
-        return True
 
     def retrieve(self):
         if self._pix_fmt in {"bgr24", "nv12"}:
@@ -2901,13 +2938,19 @@ class FfmpegPipeReader:
         # If the process died prematurely (e.g., libplacebo failed to init),
         # attempt a one-time filter-chain fallback before giving up.
         if self._proc is not None and self._proc.poll() is not None:
+            if self._at_known_eof():
+                return False, None
             if not self.try_fallback_chain():
                 return False, None
 
         if not self.grab():
             # grab() failed (end-of-stream or short read). If we haven't tried fallback yet,
             # switch to a safer chain once.
-            if self._mode != "p010_passthrough" and self.try_fallback_chain():
+            if (
+                self._mode != "p010_passthrough"
+                and not self._at_known_eof()
+                and self.try_fallback_chain()
+            ):
                 if not self.grab():
                     return False, None
             else:


### PR DESCRIPTION
## Summary
- prevent HDR pipe EOF from being treated as a filter-chain failure in strict libplacebo mode
- gate fallback-chain retries so they only run before known end-of-stream
- bound pre-scan skip requests to remaining frames and advance by actual skipped count

## Problem
Near EOF, pre-scan could request more skips than remaining frames. A short/empty ffmpeg read was then treated as a chain failure, and strict LP fallback exhaustion raised libplacebo(Vulkan) produced no frames instead of returning normal EOS.

## Notes
- no repository tests were run (per repo instruction)
- validated by static inspection and python3 -m py_compile person_capture/video_io.py person_capture/gui_app.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-of-stream detection to avoid misreads at file boundaries.
  * Fixed prescan and frame-skip logic so playback cannot advance past remaining frames and frame indices advance correctly after skips.
  * Hardened read/grab failure handling to treat known EOF as clean termination, emit clearer status messages, and suppress unnecessary recovery attempts for EOF/short reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->