### PR TITLE
Fix HDR capture seek behavior and pipe pixel format defaults

### DIFF
--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -840,6 +840,7 @@ class Processor(QtCore.QObject):
                             tgt,
                             fast=bool(getattr(cfg, "seek_fast", True)),
                             max_grabs=int(getattr(cfg, "seek_max_grabs", 12)),
+                            allow_partial=True,
                             hdr_reader=self._hdr_preview_reader,
                         )
                         # ensure forward progress even if seek advanced < stride
@@ -932,6 +933,7 @@ class Processor(QtCore.QObject):
                             tgt,
                             fast=bool(getattr(cfg, "seek_fast", True)),
                             max_grabs=int(getattr(cfg, "seek_max_grabs", 12)),
+                            allow_partial=True,
                             hdr_reader=self._hdr_preview_reader,
                         )
                         i_floor = (new_pos // stride) * stride
@@ -1268,6 +1270,7 @@ class Processor(QtCore.QObject):
                                 j,
                                 fast=bool(getattr(cfg, "seek_fast", True)),
                                 max_grabs=int(getattr(cfg, "seek_max_grabs", 12)),
+                                allow_partial=False,
                                 hdr_reader=self._hdr_preview_reader,
                             )
                             ret, frame = cap.read()
@@ -1315,6 +1318,7 @@ class Processor(QtCore.QObject):
                                     j,
                                     fast=bool(getattr(cfg, "seek_fast", True)),
                                     max_grabs=int(getattr(cfg, "seek_max_grabs", 12)),
+                                    allow_partial=False,
                                     hdr_reader=self._hdr_preview_reader,
                                 )
                                 ret, frame = cap.read()
@@ -2208,7 +2212,7 @@ class Processor(QtCore.QObject):
         fast: bool = False,
         max_grabs: int = 0,
         peek_preview: bool = False,
-        allow_partial: bool = True,
+        allow_partial: bool = False,
         hdr_reader=None,
     ) -> int:
         """Keyframe-aware seek. Fast UI seeks may return before target; internal jumps must not."""
@@ -3575,6 +3579,7 @@ class Processor(QtCore.QObject):
                         fast=bool(getattr(self.cfg, "seek_fast", True)),
                         max_grabs=int(getattr(self.cfg, "seek_max_grabs", 12)),
                         peek_preview=True,  # UI scrub: allow peeks
+                        allow_partial=True,
                         hdr_reader=self._hdr_preview_reader,
                     )
                     self.progress.emit(frame_idx)

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -2208,24 +2208,49 @@ class Processor(QtCore.QObject):
         fast: bool = False,
         max_grabs: int = 0,
         peek_preview: bool = False,
+        allow_partial: bool = True,
         hdr_reader=None,
     ) -> int:
-        """Keyframe-aware seek. If fast=True, cap forward grabs to max_grabs to avoid long stalls."""
+        """Keyframe-aware seek. Fast UI seeks may return before target; internal jumps must not."""
         if self._total_frames is not None:
             tgt_idx = max(0, min(self._total_frames - 1, int(tgt_idx)))
-        base = tgt_idx
-        ks = self._keyframes
-        if ks:
-            i = bisect.bisect_right(ks, tgt_idx) - 1
-            if i >= 0:
-                base = int(ks[i])
-        # If we have no KF info or landed exactly on tgt, choose a near target base in fast mode
-        if fast and (not ks or base == tgt_idx):
-            mg = max_grabs
-            if mg <= 0:
-                f = float(self._fps or 30.0)
-                mg = max(15, min(240, int(round(f))))
-            base = max(0, tgt_idx - int(mg))
+
+        # The external HDR ffmpeg pipe already seeks by timestamp and lets ffmpeg do
+        # accurate decode/drop internally. Rewinding it to the previous container
+        # keyframe and then capped-grabbing in Python is both slower and can livelock
+        # when a segment jump is repeatedly time-capped before reaching tgt_idx.
+        direct_pipe_seek = bool(getattr(cap, "_is_hdr_pipe", False))
+        if direct_pipe_seek:
+            base = tgt_idx
+            ks = []
+        else:
+            base = tgt_idx
+            ks = self._keyframes
+            if ks:
+                i = bisect.bisect_right(ks, tgt_idx) - 1
+                if i >= 0:
+                    base = int(ks[i])
+
+            # If a previous partial fast seek already decoded past the selected
+            # keyframe, continue forward from the current position instead of
+            # seeking backward to the same base again. Otherwise repeated
+            # time-capped seeks can make zero net progress.
+            try:
+                cur_i = int(cur_idx)
+            except Exception:
+                cur_i = -1
+            if fast and base < cur_i <= tgt_idx:
+                base = cur_i
+
+            # If we have no KF info or landed exactly on tgt, choose a near target
+            # base only for partial/UI seeks. Internal segment jumps must reach
+            # their target in a single call.
+            if fast and allow_partial and (not ks or base == tgt_idx):
+                mg = max_grabs
+                if mg <= 0:
+                    f = float(self._fps or 30.0)
+                    mg = max(15, min(240, int(round(f))))
+                base = max(0, tgt_idx - int(mg))
         if base != cur_idx:
             # time-based reposition is often faster on some backends; fall back if it fails
             if fast and self._fps:
@@ -2237,8 +2262,9 @@ class Processor(QtCore.QObject):
             self._hdr_preview_seek(base, reader=hdr_reader)
         idx = base
         limit = max(0, tgt_idx - base)
-        # Cap forward grabs in fast mode to keep UI responsive
-        if fast:
+        # Cap forward grabs only for partial/UI fast seeks. Segment jumps in the
+        # processing pass must not return before the requested keep-span start.
+        if fast and allow_partial:
             if max_grabs <= 0:
                 f = float(self._fps or 30.0)
                 max_grabs = max(15, min(240, int(round(f))))
@@ -2253,9 +2279,9 @@ class Processor(QtCore.QObject):
                     )
                 except Exception:
                     pass
-        # Time-budgeted forward grabs to avoid long decode stalls
-        t0 = time.perf_counter() if fast else None
-        budget = 0.15  # ~150 ms max spent per seek
+        # Time-budgeted forward grabs to avoid long decode stalls during UI seeks.
+        t0 = time.perf_counter() if (fast and allow_partial) else None
+        budget = 0.15  # ~150 ms max spent per partial/UI seek
         for i in range(limit):
             if not cap.grab():
                 break
@@ -2275,7 +2301,7 @@ class Processor(QtCore.QObject):
                     self._hdr_preview_skip(1, reader=hdr_reader)
             else:
                 self._hdr_preview_skip(1, reader=hdr_reader)
-            if fast and (time.perf_counter() - t0) > budget:
+            if fast and allow_partial and t0 is not None and (time.perf_counter() - t0) > budget:
                 try:
                     self._status(
                         f"Fast-seek time-capped at {idx - base} grabs",
@@ -3223,6 +3249,7 @@ class Processor(QtCore.QObject):
                         fast=bool(getattr(cfg, "seek_fast", True)),
                         max_grabs=int(getattr(cfg, "seek_max_grabs", 12)),
                         peek_preview=False,  # segment jump: no peeks
+                        allow_partial=False,
                         hdr_reader=self._hdr_preview_reader,
                     )
                     # Neutralize any stray cooldown/coalesced state from the jump *before* progress emit.
@@ -3592,6 +3619,7 @@ class Processor(QtCore.QObject):
                             fast=bool(getattr(self.cfg, "seek_fast", True)),
                             max_grabs=int(getattr(self.cfg, "seek_max_grabs", 12)),
                             peek_preview=False,  # segment jump: no peeks
+                            allow_partial=False,
                             hdr_reader=self._hdr_preview_reader,
                         )
                         self._seek_cooldown_frames = int(max(2, (self._fps or 30) * 0.25))
@@ -3608,6 +3636,7 @@ class Processor(QtCore.QObject):
                             fast=bool(getattr(self.cfg, "seek_fast", True)),
                             max_grabs=int(getattr(self.cfg, "seek_max_grabs", 12)),
                             peek_preview=False,  # segment jump: no peeks
+                            allow_partial=False,
                             hdr_reader=self._hdr_preview_reader,
                         )
                         self._seek_cooldown_frames = int(max(2, (self._fps or 30) * 0.25))

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -1176,7 +1176,7 @@ class FfmpegPipeReader:
         # converter. This is both faster in the capture loop and avoids range/matrix
         # ambiguity that can make HDR screenshots look washed out. The fallback ladder
         # still switches to NV12 if pipe allocation fails.
-        self._pipe_pixfmt = (os.getenv("PC_PIPE_PIXFMT", "bgr24") or "bgr24").lower()
+        self._pipe_pixfmt = (os.getenv("PC_PIPE_PIXFMT", "bgr24") or "bgr24").strip().lower()
         if self._pipe_pixfmt not in ("bgr24", "nv12"):
             self._log.warning("Unsupported PC_PIPE_PIXFMT=%s; using bgr24", self._pipe_pixfmt)
             self._pipe_pixfmt = "bgr24"

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -1171,9 +1171,15 @@ class FfmpegPipeReader:
         self._tm_algo = (os.getenv("PC_TM_ALGO", "auto") or "auto")
         # Strict libplacebo: never allow CPU/zscale fallback and avoid multi-probe churn.
         self._strict_lp = (os.getenv("PC_LP_STRICT", "1").lower() not in ("0", "false", "no"))
-        # Pipe pixel format: keep pipe light to avoid ENOMEM on pipe:1
-        # Default nv12 (1.5 B/px). Change to bgr24 if you explicitly want RGB pipe.
-        self._pipe_pixfmt = (os.getenv("PC_PIPE_PIXFMT", "nv12") or "nv12").lower()
+        # Pipe pixel format for tone-mapped output. Default to BGR24 so saved crops
+        # use ffmpeg/libplacebo's RGB conversion directly instead of the Python NV12
+        # converter. This is both faster in the capture loop and avoids range/matrix
+        # ambiguity that can make HDR screenshots look washed out. The fallback ladder
+        # still switches to NV12 if pipe allocation fails.
+        self._pipe_pixfmt = (os.getenv("PC_PIPE_PIXFMT", "bgr24") or "bgr24").lower()
+        if self._pipe_pixfmt not in ("bgr24", "nv12"):
+            self._log.warning("Unsupported PC_PIPE_PIXFMT=%s; using bgr24", self._pipe_pixfmt)
+            self._pipe_pixfmt = "bgr24"
         # Input/demux probe budgets
         try:
             self._probe_m = max(1, int(os.getenv("PC_FF_PROBE_M", "48")))


### PR DESCRIPTION
## Summary
- apply the provided HDR capture fix patch
- add allow_partial controls so internal segment seeks are not time-capped/partial
- treat HDR ffmpeg pipe seeks as direct timestamp seeks to avoid repeated keyframe rewind stalls
- default PC_PIPE_PIXFMT to bgr24 with validation and fallback to bgr24 for unsupported values

## Notes
- patch applied in a clean worktree branch (/tmp/person_capture_capture_hdr_fix_wt) to avoid touching unrelated local changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster, more responsive UI preview scrubbing with reduced stalls and fewer backward rewinds during quick seeks; internal segment navigation remains accurate.

* **Improvements**
  * HDR/video pipe output now defaults to an optimized RGB/BGR pixel format for better color handling.
  * Video format setting validation added; invalid values are warned and reset to a supported format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->