### PR TITLE
Fix HDR seek path around EOF and stabilize ffmpeg/libplacebo color targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ Thumbs.db
 /.ultralytics
 /person_capture/output/index.csv
 /person_capture/pc_hdr_pipelines.cache
-/pc_hdr_vulkan.dll
 /onnxruntime/
 
 .codex

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,7 @@ Thumbs.db
 /.ultralytics
 /person_capture/output/index.csv
 /person_capture/pc_hdr_pipelines.cache
+/pc_hdr_vulkan.dll
+/onnxruntime/
 
 .codex

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -2255,9 +2255,24 @@ class Processor(QtCore.QObject):
                     f = float(self._fps or 30.0)
                     mg = max(15, min(240, int(round(f))))
                 base = max(0, tgt_idx - int(mg))
-        if base != cur_idx:
-            # time-based reposition is often faster on some backends; fall back if it fails
-            if fast and self._fps:
+        # For OpenCV readers, cur_idx is the caller's processing cursor. For
+        # HDR ffmpeg pipes, some pre-scan callers pass the desired index as
+        # cur_idx even after the pipe has advanced to EOF. Compare against the
+        # pipe's real next index so a requested seek cannot be skipped.
+        cur_for_seek = cur_idx
+        if direct_pipe_seek:
+            try:
+                cur_for_seek = int(cap._next_frame_index())
+            except Exception:
+                try:
+                    cur_for_seek = int(cap.get(cv2.CAP_PROP_POS_FRAMES))
+                except Exception:
+                    cur_for_seek = -1
+        if base != cur_for_seek:
+            # time-based reposition is often faster on some backends; fall back if it fails.
+            # HDR ffmpeg pipes implement only frame-based seeking and add their own small
+            # preroll internally, so do not route those seeks through POS_MSEC.
+            if fast and self._fps and not direct_pipe_seek:
                 ok = cap.set(cv2.CAP_PROP_POS_MSEC, (base / float(self._fps)) * 1000.0)
                 if not ok:
                     cap.set(cv2.CAP_PROP_POS_FRAMES, base)

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -1530,16 +1530,21 @@ class FfmpegPipeReader:
     def _at_known_eof(self, next_idx: Optional[int] = None) -> bool:
         if next_idx is None:
             next_idx = self._next_frame_index()
-        next_i = int(next_idx)
         total = self._known_total_frames()
-        if total > 0:
-            return next_i >= total
-        # MKV/remux streams often lack nb_frames, so _nb may be duration-derived.
-        # Treat only the final estimated frame as soft EOF. This prevents strict
-        # libplacebo fallback from turning normal late-seek EOF into a fatal
-        # "produced no frames" error while preserving real mid-stream failures.
+        return total > 0 and int(next_idx) >= total
+
+    def _at_soft_eof(self, next_idx: Optional[int] = None) -> bool:
+        """
+        Best-effort EOF for post-failure handling only.
+        Uses estimated totals when exact frame counts are unavailable so late
+        tail short-reads do not trigger expensive fallback ladders.
+        """
+        if next_idx is None:
+            next_idx = self._next_frame_index()
+        if self._at_known_eof(next_idx):
+            return True
         total = self._stream_total_frames()
-        return total > 0 and next_i >= max(0, total - 1)
+        return total > 0 and int(next_idx) >= max(0, total - 1)
 
     def _ensure_started(self) -> bool:
         proc = self._proc
@@ -1719,7 +1724,7 @@ class FfmpegPipeReader:
         # not evidence that the active filter chain failed. This matters for
         # late pre-scan skips and deferred probes: strict LP must not turn EOF
         # into a fatal "produced no frames" error.
-        if self._at_known_eof():
+        if self._at_soft_eof():
             return False
         if self._fallback_hops >= getattr(self, "_fallback_hops_max", 12):
             self._log.error("LP fallback exhausted after %s hops.", self._fallback_hops)
@@ -2453,10 +2458,11 @@ class FfmpegPipeReader:
         return s
 
     def _start(self, idx: int, *, drop_until: Optional[int] = None):
+        pending_drop_until = self._drop_until if drop_until is None else int(drop_until)
         if self._proc:
             self._stop()
         if self._mode == "p010_passthrough":
-            self._start_p010(idx, drop_until=drop_until)
+            self._start_p010(idx, drop_until=pending_drop_until)
             return
         # Apply the very first probe mode before constructing the command.
         if self._mode == "libplacebo" and self._use_libplacebo and self._has_vulkan:
@@ -2571,7 +2577,7 @@ class FfmpegPipeReader:
             creationflags=flags,
         )
         self._stderr_tail = []
-        self._drop_until = int(drop_until) if drop_until is not None else None
+        self._drop_until = pending_drop_until
 
         def _drain() -> None:
             try:
@@ -2596,6 +2602,7 @@ class FfmpegPipeReader:
         self._pix_fmt = pix_fmt
 
     def _start_p010(self, idx: int, *, drop_until: Optional[int] = None) -> None:
+        pending_drop_until = self._drop_until if drop_until is None else int(drop_until)
         if self._proc:
             self._stop()
         t = 0.0 if self._fps <= 0 else max(0.0, idx / float(self._fps))
@@ -2683,7 +2690,7 @@ class FfmpegPipeReader:
             creationflags=flags,
         )
         self._stderr_tail = []
-        self._drop_until = int(drop_until) if drop_until is not None else None
+        self._drop_until = pending_drop_until
 
         def _drain() -> None:
             try:
@@ -2776,9 +2783,6 @@ class FfmpegPipeReader:
     def set(self, prop: int, value: float) -> bool:
         if prop == CV_CAP_PROP_POS_FRAMES:
             target = max(0, int(value))
-            total = self._stream_total_frames()
-            if total > 0:
-                target = min(target, total - 1)
             try:
                 if self._proc is not None and self._next_frame_index() == target:
                     self._drop_until = None
@@ -2867,7 +2871,7 @@ class FfmpegPipeReader:
                 self._last_startup_error = None
             except Exception as exc:
                 self._last_startup_error = exc
-                if self._mode != "p010_passthrough" and not self._at_known_eof():
+                if self._mode != "p010_passthrough" and not self._at_soft_eof():
                     self._log.warning(
                         "HDR pipe startup failed during grab; trying fallback: %s",
                         exc,
@@ -2880,7 +2884,7 @@ class FfmpegPipeReader:
             if not started or not self._proc or not self._proc.stdout:
                 if (
                     self._mode != "p010_passthrough"
-                    and not self._at_known_eof()
+                    and not self._at_soft_eof()
                     and self.try_fallback_chain()
                 ):
                     continue
@@ -2893,7 +2897,7 @@ class FfmpegPipeReader:
                     # EOF/late-seek-empty is a normal false return. Only run
                     # the expensive LP fallback ladder when the short read
                     # occurs before the known end of the stream.
-                    if self._mode != "p010_passthrough" and not self._at_known_eof():
+                    if self._mode != "p010_passthrough" and not self._at_soft_eof():
                         if self.try_fallback_chain():
                             continue
                     return False
@@ -2991,7 +2995,7 @@ class FfmpegPipeReader:
         # If the process died prematurely (e.g., libplacebo failed to init),
         # attempt a one-time filter-chain fallback before giving up.
         if self._proc is not None and self._proc.poll() is not None:
-            if self._at_known_eof():
+            if self._at_soft_eof():
                 self._last_startup_error = None
                 return False, None
             if not self.try_fallback_chain():
@@ -3002,7 +3006,7 @@ class FfmpegPipeReader:
             # switch to a safer chain once.
             if (
                 self._mode != "p010_passthrough"
-                and not self._at_known_eof()
+                and not self._at_soft_eof()
                 and self.try_fallback_chain()
             ):
                 if not self.grab():

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -1543,8 +1543,9 @@ class FfmpegPipeReader:
         """
         if next_idx is None:
             next_idx = self._next_frame_index()
-        if self._at_known_eof(next_idx):
-            return True
+        known_total = self._known_total_frames()
+        if known_total > 0:
+            return int(next_idx) >= known_total
         total = self._stream_total_frames()
         return total > 0 and int(next_idx) >= max(0, total - 1)
 
@@ -2804,6 +2805,8 @@ class FfmpegPipeReader:
                     and getattr(proc, "poll", lambda: 1)() is None
                     and self._next_frame_index() == target
                 ):
+                    self._arr = None
+                    self._pipe_buf = None
                     self._drop_until = None
                     return True
             except Exception:

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -2798,7 +2798,12 @@ class FfmpegPipeReader:
         if prop == CV_CAP_PROP_POS_FRAMES:
             target = max(0, int(value))
             try:
-                if self._proc is not None and self._next_frame_index() == target:
+                proc = self._proc
+                if (
+                    proc is not None
+                    and getattr(proc, "poll", lambda: 1)() is None
+                    and self._next_frame_index() == target
+                ):
                     self._drop_until = None
                     return True
             except Exception:

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -1340,6 +1340,11 @@ class FfmpegPipeReader:
         self._proc = None
         self._arr: Optional[np.ndarray] = None
         self._pipe_buf: Optional[bytes] = None
+        self._drop_until: Optional[int] = None
+        try:
+            self._seek_preroll_frames = max(0, int(os.getenv("PC_FF_SEEK_PREROLL_FRAMES", "12")))
+        except Exception:
+            self._seek_preroll_frames = 12
         self._stderr_thread = None
         self._stderr_tail: list[str] = []
         self._lp_opts: dict[str, bool] = {}
@@ -1504,14 +1509,17 @@ class FfmpegPipeReader:
             return
         self._start(0)
 
-    def _known_total_frames(self) -> int:
-        if not bool(getattr(self, "_total_is_exact", False)):
-            return 0
+    def _stream_total_frames(self) -> int:
         try:
             total = int(getattr(self, "_nb", 0) or getattr(self, "_total", 0) or 0)
         except (TypeError, ValueError):
             total = 0
         return max(0, total)
+
+    def _known_total_frames(self) -> int:
+        if not bool(getattr(self, "_total_is_exact", False)):
+            return 0
+        return self._stream_total_frames()
 
     def _next_frame_index(self) -> int:
         try:
@@ -1520,12 +1528,18 @@ class FfmpegPipeReader:
             return 0
 
     def _at_known_eof(self, next_idx: Optional[int] = None) -> bool:
-        total = self._known_total_frames()
-        if total <= 0:
-            return False
         if next_idx is None:
             next_idx = self._next_frame_index()
-        return int(next_idx) >= total
+        next_i = int(next_idx)
+        total = self._known_total_frames()
+        if total > 0:
+            return next_i >= total
+        # MKV/remux streams often lack nb_frames, so _nb may be duration-derived.
+        # Treat only the final estimated frame as soft EOF. This prevents strict
+        # libplacebo fallback from turning normal late-seek EOF into a fatal
+        # "produced no frames" error while preserving real mid-stream failures.
+        total = self._stream_total_frames()
+        return total > 0 and next_i >= max(0, total - 1)
 
     def _ensure_started(self) -> bool:
         proc = self._proc
@@ -1604,16 +1618,18 @@ class FfmpegPipeReader:
         manual NV12→BGR converter (which assumes TV/limited) sees the expected
         16–235/16–240 range. For RGB-family pipes we prefer full range.
         """
-        # Single modern umbrella first if present
+        # Set every target color component this build exposes. The umbrella
+        # colorspace option is not enough on all ffmpeg/libplacebo builds; if
+        # color_trc remains inherited from a PQ source, BGR screenshots can look
+        # washed out even though tonemapping ran.
         if self._lp_supports_any("colorspace"):
             lp_args.append("colorspace=bt709")
-        else:
-            p = self._lp_supports_any("target_primaries", "color_primaries")
-            t = self._lp_supports_any("target_trc", "color_trc")
-            if p:
-                lp_args.append(f"{p}=bt709")
-            if t:
-                lp_args.append(f"{t}=bt709")
+        p = self._lp_supports_any("target_primaries", "color_primaries")
+        t = self._lp_supports_any("target_trc", "color_trc")
+        if p:
+            lp_args.append(f"{p}=bt709")
+        if t:
+            lp_args.append(f"{t}=bt709")
         if self._lp_supports_any("range"):
             tail = (getattr(self, "_pipe_pixfmt", "") or "").lower()
             rng = "limited" if tail == "nv12" else "full"
@@ -2436,11 +2452,11 @@ class FfmpegPipeReader:
         s += ",format=gbrpf32le,setsar=1"
         return s
 
-    def _start(self, idx: int):
+    def _start(self, idx: int, *, drop_until: Optional[int] = None):
         if self._proc:
             self._stop()
         if self._mode == "p010_passthrough":
-            self._start_p010(idx)
+            self._start_p010(idx, drop_until=drop_until)
             return
         # Apply the very first probe mode before constructing the command.
         if self._mode == "libplacebo" and self._use_libplacebo and self._has_vulkan:
@@ -2555,6 +2571,7 @@ class FfmpegPipeReader:
             creationflags=flags,
         )
         self._stderr_tail = []
+        self._drop_until = int(drop_until) if drop_until is not None else None
 
         def _drain() -> None:
             try:
@@ -2578,7 +2595,7 @@ class FfmpegPipeReader:
         self._pipe_buf = None
         self._pix_fmt = pix_fmt
 
-    def _start_p010(self, idx: int) -> None:
+    def _start_p010(self, idx: int, *, drop_until: Optional[int] = None) -> None:
         if self._proc:
             self._stop()
         t = 0.0 if self._fps <= 0 else max(0.0, idx / float(self._fps))
@@ -2666,6 +2683,7 @@ class FfmpegPipeReader:
             creationflags=flags,
         )
         self._stderr_tail = []
+        self._drop_until = int(drop_until) if drop_until is not None else None
 
         def _drain() -> None:
             try:
@@ -2738,6 +2756,7 @@ class FfmpegPipeReader:
         self._proc = None
         self._arr = None
         self._pipe_buf = None
+        self._drop_until = None
 
     # OpenCV-like API
     def get(self, prop: int) -> float:
@@ -2756,7 +2775,19 @@ class FfmpegPipeReader:
 
     def set(self, prop: int, value: float) -> bool:
         if prop == CV_CAP_PROP_POS_FRAMES:
-            self._start(max(0, int(value)))
+            target = max(0, int(value))
+            total = self._stream_total_frames()
+            if total > 0:
+                target = min(target, total - 1)
+            try:
+                if self._proc is not None and self._next_frame_index() == target:
+                    self._drop_until = None
+                    return True
+            except Exception:
+                pass
+            preroll = int(getattr(self, "_seek_preroll_frames", 12) or 0)
+            base = max(0, target - preroll) if target > 0 and preroll > 0 else target
+            self._start(base, drop_until=(target if base < target else None))
             return True
         return False
 
@@ -2866,9 +2897,15 @@ class FfmpegPipeReader:
                         if self.try_fallback_chain():
                             continue
                     return False
+                next_pos = int(self._pos) + 1
+                drop_until = getattr(self, "_drop_until", None)
+                if drop_until is not None and next_pos < int(drop_until):
+                    self._pos = next_pos
+                    continue
+                self._drop_until = None
                 self._pipe_buf = buf
                 self._arr = None
-                self._pos += 1
+                self._pos = next_pos
                 return True
 
             # Linear+python-tonemap path: read float32 RGB (planar G,B,R)
@@ -2885,9 +2922,15 @@ class FfmpegPipeReader:
                 rgb_linear = _eotf_hlg(rgb)
             else:
                 rgb_linear = _eotf_pq(rgb)
+            next_pos = int(self._pos) + 1
+            drop_until = getattr(self, "_drop_until", None)
+            if drop_until is not None and next_pos < int(drop_until):
+                self._pos = next_pos
+                continue
+            self._drop_until = None
             self._arr = rgb_linear
             self._pipe_buf = None
-            self._pos += 1
+            self._pos = next_pos
             return True
 
     def retrieve(self):

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -1771,7 +1771,7 @@ class FfmpegPipeReader:
                 raise RuntimeError(msg)
 
             self._log.warning("%s Falling back to zscale/scale CPU tonemapping.", msg)
-            self._stop()
+            self._stop(clear_drop_until=False)
             self._mode = "zscale" if (self._has_zscale and self._has_tonemap) else "scale"
             self._fallback_hops = 0
             _restart(max(self._pos + 1, 0))
@@ -1956,7 +1956,7 @@ class FfmpegPipeReader:
                         return True
                     if (self._has_zscale and self._has_tonemap) and not self._tried_zscale:
                         self._log.warning("HDR: LP mem fault persists → falling back to zscale+tonemap.")
-                        self._stop()
+                        self._stop(clear_drop_until=False)
                         self._mode = "zscale"
                         self._fallback_hops = 0
                         self._tried_zscale = True
@@ -2037,7 +2037,7 @@ class FfmpegPipeReader:
             if (self._has_zscale and self._has_tonemap) and not self._tried_zscale:
                 _log_tail("HDR: libplacebo yielded no frames;")
                 self._log.warning("HDR: libplacebo yielded no frames; falling back to zscale+tonemap.")
-                self._stop()
+                self._stop(clear_drop_until=False)
                 self._mode = "zscale"
                 self._fallback_hops = 0
                 self._tried_zscale = True
@@ -2046,7 +2046,7 @@ class FfmpegPipeReader:
             if self._has_scale and not self._tried_scale:
                 _log_tail("HDR: libplacebo yielded no frames;")
                 self._log.warning("HDR: libplacebo yielded no frames; falling back to linear scale.")
-                self._stop()
+                self._stop(clear_drop_until=False)
                 self._mode = "scale"
                 self._fallback_hops = 0
                 self._tried_scale = True
@@ -2056,7 +2056,7 @@ class FfmpegPipeReader:
         if self._mode == "zscale":
             if self._has_scale and not self._tried_scale:
                 self._log.warning("HDR: zscale+tonemap yielded no frames; falling back to linear scale.")
-                self._stop()
+                self._stop(clear_drop_until=False)
                 self._mode = "scale"
                 self._fallback_hops = 0
                 self._tried_scale = True
@@ -2749,7 +2749,7 @@ class FfmpegPipeReader:
         except Exception:
             return False
 
-    def _stop(self):
+    def _stop(self, *, clear_drop_until: bool = True):
         # Idempotent; callers may invoke multiple times during fallback.
         try:
             if self._proc:
@@ -2776,7 +2776,8 @@ class FfmpegPipeReader:
         self._proc = None
         self._arr = None
         self._pipe_buf = None
-        self._drop_until = None
+        if clear_drop_until:
+            self._drop_until = None
 
     # OpenCV-like API
     def get(self, prop: int) -> float:

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -1562,6 +1562,7 @@ class FfmpegPipeReader:
         try:
             self._start(next_idx, drop_until=pending_drop_until)
         except Exception as exc:
+            self._drop_until = pending_drop_until
             self._log.warning("HDR pipe lazy start failed at frame %d: %s", next_idx, exc)
             raise
         proc = self._proc
@@ -2810,7 +2811,12 @@ class FfmpegPipeReader:
                     self._drop_until = None
                     return True
             except Exception:
-                pass
+                self._log.debug(
+                    "HDR seek fast-path probe failed (target=%s, proc_present=%s)",
+                    target,
+                    self._proc is not None,
+                    exc_info=True,
+                )
             preroll = int(getattr(self, "_seek_preroll_frames", 12) or 0)
             base = max(0, target - preroll) if target > 0 and preroll > 0 else target
             self._start(base, drop_until=(target if base < target else None))

--- a/person_capture/video_io.py
+++ b/person_capture/video_io.py
@@ -35,6 +35,8 @@ except Exception:
     CV_CAP_PROP_FRAME_WIDTH = 3
     CV_CAP_PROP_FRAME_HEIGHT = 4
 
+_PRESERVE_DROP_UNTIL = object()
+
 
 def _ffprobe_path() -> Optional[str]:
     """
@@ -1550,13 +1552,14 @@ class FfmpegPipeReader:
         proc = self._proc
         if proc is not None and getattr(proc, "poll", lambda: 1)() is None:
             return True
+        pending_drop_until = self._drop_until
         if proc is not None:
             self._stop()
         next_idx = self._next_frame_index()
         if self._at_known_eof(next_idx):
             return False
         try:
-            self._start(next_idx)
+            self._start(next_idx, drop_until=pending_drop_until)
         except Exception as exc:
             self._log.warning("HDR pipe lazy start failed at frame %d: %s", next_idx, exc)
             raise
@@ -2457,8 +2460,13 @@ class FfmpegPipeReader:
         s += ",format=gbrpf32le,setsar=1"
         return s
 
-    def _start(self, idx: int, *, drop_until: Optional[int] = None):
-        pending_drop_until = self._drop_until if drop_until is None else int(drop_until)
+    def _start(self, idx: int, *, drop_until: object = _PRESERVE_DROP_UNTIL):
+        if drop_until is _PRESERVE_DROP_UNTIL:
+            pending_drop_until = self._drop_until
+        elif drop_until is None:
+            pending_drop_until = None
+        else:
+            pending_drop_until = int(drop_until)
         if self._proc:
             self._stop()
         if self._mode == "p010_passthrough":
@@ -2601,8 +2609,13 @@ class FfmpegPipeReader:
         self._pipe_buf = None
         self._pix_fmt = pix_fmt
 
-    def _start_p010(self, idx: int, *, drop_until: Optional[int] = None) -> None:
-        pending_drop_until = self._drop_until if drop_until is None else int(drop_until)
+    def _start_p010(self, idx: int, *, drop_until: object = _PRESERVE_DROP_UNTIL) -> None:
+        if drop_until is _PRESERVE_DROP_UNTIL:
+            pending_drop_until = self._drop_until
+        elif drop_until is None:
+            pending_drop_until = None
+        else:
+            pending_drop_until = int(drop_until)
         if self._proc:
             self._stop()
         t = 0.0 if self._fps <= 0 else max(0.0, idx / float(self._fps))


### PR DESCRIPTION
## Summary
- add .gitignore entries for pc_hdr_vulkan.dll and onnxruntime/
- fix GUI seek-base comparison for HDR direct-pipe readers by using the pipe real next-frame index
- avoid routing direct-pipe seeks through CAP_PROP_POS_MSEC and keep frame-based seeking
- improve HDR reader EOF handling when exact frame totals are unavailable
- force target primaries and transfer settings when supported to avoid inherited PQ washout in BGR screenshots

## Notes
- patch applied from person_capture_hdr_seek_fix_v2.diff and transferred to a clean worktree branch for commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HDR seeking now correctly detects current position and routes seeks through frame-based paths when needed, avoiding false "already at target" results.
  * Improved preroll-aware seeking to maintain accurate frame positioning and avoid consuming frames before user-requested positions.
  * Better end-of-stream handling to prevent late short-read fallbacks and preserve consistent frame indexing.
  * Enhanced HDR color handling where supported.

* **Chores**
  * Ignore rule added for root-level onnxruntime/ directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->