### PR TITLE
Fix remaining WIC blue halos and prevent SDR AVIF chroma smear

### DIFF
--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -7485,29 +7485,54 @@ class Processor(QtCore.QObject):
             # confined to hair/clothes/shadow regions.
             luma = np.clip((0.114 * b + 0.587 * g + 0.299 * r), 0, 255).astype(np.uint8)
             local_luma = cv2.medianBlur(luma, 5)
-            dark = local_luma <= 112
-            blue = dark & (b >= 160) & ((b - max_rg) >= 50) & (r <= 96) & (g <= 96)
+            dark = local_luma <= 128
+            # The remaining WIC failures are not always a one-pixel core. They
+            # can leave a short, lower-intensity blue halo around the saturated
+            # pixel, and 4:2:0 AVIF chroma subsampling makes that halo visible
+            # even after the old exact-pixel mask removed the brightest center.
+            # Use a strict seed for impossible blue pixels, then grow only into
+            # nearby low-intensity blue contamination. Keep red/magenta on the
+            # original strict thresholds so normal warm shadow detail is not
+            # pulled into the repair mask.
+            blue_seed = dark & (
+                ((b >= 145) & ((b - max_rg) >= 45) & (r <= 112) & (g <= 112))
+                | ((b >= 88) & ((b - max_rg) >= 60) & (r <= 40) & (g <= 40))
+            )
+            blue_halo = dark & (b >= 70) & ((b - max_rg) >= 22) & (r <= 128) & (g <= 128)
             magenta = dark & (r >= 160) & (b >= 160) & ((min_rb - g) >= 50) & (g <= 96)
             red = dark & (r >= 180) & ((r - max_bg) >= 70) & (b <= 80) & (g <= 80)
-            mask = (blue | magenta | red).astype(np.uint8)
+            blue_near_seed = cv2.dilate(
+                blue_seed.astype(np.uint8),
+                np.ones((5, 5), dtype=np.uint8),
+                iterations=1,
+            ).astype(bool)
+            seed = blue_seed | magenta | red
+            mask = (seed | (blue_halo & blue_near_seed)).astype(np.uint8)
             if int(mask.sum()) <= 0:
                 return 0
-            # Reject broad regions. The defect is salt-like; connected areas much
-            # larger than this are likely real image content or a bad threshold.
+            # Reject broad regions. Blue WIC faults can be short streaks after
+            # display conversion, so accept slightly larger/longer blue-seeded
+            # components; keep the previous compact-component rule for strict
+            # red/magenta seeds.
             n, labels, stats, _ = cv2.connectedComponentsWithStats(mask, 8)
             keep = np.zeros_like(mask, dtype=np.uint8)
             for i in range(1, n):
                 area = int(stats[i, cv2.CC_STAT_AREA])
                 if area <= 0:
                     continue
-                if 1 <= area <= 4:
-                    keep[labels == i] = 255
-                    continue
-                if not (5 <= area <= 80):
-                    continue
                 bbox_w = int(stats[i, cv2.CC_STAT_WIDTH])
                 bbox_h = int(stats[i, cv2.CC_STAT_HEIGHT])
                 if bbox_w <= 0 or bbox_h <= 0:
+                    continue
+                component = labels == i
+                if bool(np.any(blue_seed[component])):
+                    if area <= 220 and bbox_w <= 32 and bbox_h <= 32:
+                        keep[component] = 255
+                    continue
+                if 1 <= area <= 4:
+                    keep[component] = 255
+                    continue
+                if not (5 <= area <= 80):
                     continue
                 long_edge = max(bbox_w, bbox_h)
                 short_edge = max(1, min(bbox_w, bbox_h))
@@ -7515,12 +7540,12 @@ class Processor(QtCore.QObject):
                 # Preserve tiny compact blobs, but reject thin/elongated regions
                 # that are more likely real scene detail than WIC salt speckles.
                 if long_edge <= 12 and (long_edge / short_edge) <= 3.0 and fill_ratio >= 0.40:
-                    keep[labels == i] = 255
+                    keep[component] = 255
             changed = int(np.count_nonzero(keep))
             if changed <= 0:
                 return 0
-            # Inpaint exact defective pixels from surrounding good WIC-rendered
-            # pixels. Do not dilate the mask; that would alter valid fine detail.
+            # Inpaint only the connected defective component from surrounding
+            # good WIC-rendered pixels. Do not globally blur or denoise.
             repaired = cv2.inpaint(bgr, keep, 2.0, cv2.INPAINT_TELEA)
             out = img.copy()
             out[:, :, :3] = repaired
@@ -7565,7 +7590,7 @@ class Processor(QtCore.QObject):
             "-frames:v",
             "1",
             "-vf",
-            "format=yuv420p10le",
+            "format=yuv444p10le",
             "-an",
             "-sn",
             "-dn",
@@ -7574,7 +7599,7 @@ class Processor(QtCore.QObject):
             "-still-picture",
             "1",
             "-pix_fmt",
-            "yuv420p10le",
+            "yuv444p10le",
             "-g",
             "1",
             "-tile-columns",

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -7485,7 +7485,8 @@ class Processor(QtCore.QObject):
             # confined to hair/clothes/shadow regions.
             luma = np.clip((0.114 * b + 0.587 * g + 0.299 * r), 0, 255).astype(np.uint8)
             local_luma = cv2.medianBlur(luma, 5)
-            dark = local_luma <= 128
+            dark_blue = local_luma <= 128
+            dark_strict = local_luma <= 112
             # The remaining WIC failures are not always a one-pixel core. They
             # can leave a short, lower-intensity blue halo around the saturated
             # pixel, and 4:2:0 AVIF chroma subsampling makes that halo visible
@@ -7494,19 +7495,20 @@ class Processor(QtCore.QObject):
             # nearby low-intensity blue contamination. Keep red/magenta on the
             # original strict thresholds so normal warm shadow detail is not
             # pulled into the repair mask.
-            blue_seed = dark & (
+            blue_seed = dark_blue & (
                 ((b >= 145) & ((b - max_rg) >= 45) & (r <= 112) & (g <= 112))
                 | ((b >= 88) & ((b - max_rg) >= 60) & (r <= 40) & (g <= 40))
             )
-            blue_halo = dark & (b >= 70) & ((b - max_rg) >= 22) & (r <= 128) & (g <= 128)
-            magenta = dark & (r >= 160) & (b >= 160) & ((min_rb - g) >= 50) & (g <= 96)
-            red = dark & (r >= 180) & ((r - max_bg) >= 70) & (b <= 80) & (g <= 80)
+            blue_halo = dark_blue & (b >= 70) & ((b - max_rg) >= 22) & (r <= 128) & (g <= 128)
+            magenta = dark_strict & (r >= 160) & (b >= 160) & ((min_rb - g) >= 50) & (g <= 96)
+            red = dark_strict & (r >= 180) & ((r - max_bg) >= 70) & (b <= 80) & (g <= 80)
             blue_near_seed = cv2.dilate(
                 blue_seed.astype(np.uint8),
                 np.ones((5, 5), dtype=np.uint8),
                 iterations=1,
             ).astype(bool)
-            seed = blue_seed | magenta | red
+            strict_seed = magenta | red
+            seed = blue_seed | strict_seed
             mask = (seed | (blue_halo & blue_near_seed)).astype(np.uint8)
             if int(mask.sum()) <= 0:
                 return 0
@@ -7525,7 +7527,9 @@ class Processor(QtCore.QObject):
                 if bbox_w <= 0 or bbox_h <= 0:
                     continue
                 component = labels == i
-                if bool(np.any(blue_seed[component])):
+                has_blue_seed = bool(np.any(blue_seed[component]))
+                has_strict_seed = bool(np.any(strict_seed[component]))
+                if has_blue_seed and not has_strict_seed:
                     if area <= 220 and bbox_w <= 32 and bbox_h <= 32:
                         keep[component] = 255
                     continue


### PR DESCRIPTION
## Summary
- expand WIC blue defect detection from strict saturated seeds into nearby low-intensity halo pixels
- keep strict red/magenta thresholds while allowing larger short blue-seeded components
- switch display-compatible SDR AVIF encode path from yuv420p10le to yuv444p10le to avoid reintroducing blue chroma halos

## Validation
- python3 -m py_compile person_capture/gui_app.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speckle/artifact cleanup to better detect and remove blue-related contamination while preserving red/magenta details, reducing false positives and streaking.
  * Adjusted component filtering to accept larger, elongated cleanup regions when appropriate, improving inpainting locality and visual consistency.

* **Chores**
  * Switched AVIF encoding to a higher-fidelity chroma format for improved color accuracy and visual fidelity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->