### PR TITLE
Fix SCRFD startup check to avoid eager insightface import chain

### DIFF
--- a/person_capture/face_embedder.py
+++ b/person_capture/face_embedder.py
@@ -439,7 +439,9 @@ class FaceEmbedder:
             self.det = _YOLO(yolo_path)
         else:
             try:
-                from insightface.model_zoo.scrfd import SCRFD as _SCRFD  # noqa: F401
+                import importlib.util as _importlib_util
+                if _importlib_util.find_spec("insightface") is None:
+                    raise ModuleNotFoundError("No module named 'insightface'")
             except Exception as e:
                 raise RuntimeError(
                     "SCRFD backend requires 'insightface'. Install or update the package and retry."


### PR DESCRIPTION
## Summary
- replace eager `insightface.model_zoo.scrfd` import probe in `FaceEmbedder.__init__` with `importlib.util.find_spec("insightface")`
- preserve the existing runtime error path when `insightface` is not installed
- avoid importing `insightface.__init__` during startup, preventing unrelated side-effect imports in PySide runtime

## Scope
- not related to PR #332 / speckle code
- one-file minimal patch in `person_capture/face_embedder.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when required dependencies are missing, providing clearer feedback to users about package installation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->