### PR TITLE
Apply corrected prescan speed patch

### DIFF
--- a/person_capture/face_embedder.py
+++ b/person_capture/face_embedder.py
@@ -2199,7 +2199,8 @@ class FaceEmbedder:
         if self._fast_prescan:
             dyn = min(dyn, int(getattr(self, "_prescan_probe_imgsz", 384)))
             if bool(getattr(self, "_prescan_no_upscale_det", True)):
-                dyn = min(dyn, _round32(max(H0, W0)))
+                src_cap = max(320, (max(H0, W0) // 32) * 32)
+                dyn = min(dyn, src_cap)
         dyn = _round32(max(320, dyn))
         L = max(H0, W0)
         heavy_cap = max(int(getattr(self, "_heavy_cap", 2048)), dyn)  # optional safety cap

--- a/person_capture/face_embedder.py
+++ b/person_capture/face_embedder.py
@@ -483,6 +483,7 @@ class FaceEmbedder:
         self._high_180: int = 1280
         self._prescan_period: int = 3       # rotate every N prescan samples when empty
         self._prescan_probe_imgsz: int = 384
+        self._prescan_no_upscale_det: bool = True  # do not upscale already downscaled prescan frames for 0° detect
         self._heavy_cap: int = 2048
         # --- adaptive rotation controls (speed-up on empty scenes) ---
         self._frame_idx: int = 0
@@ -2093,14 +2094,11 @@ class FaceEmbedder:
 
     def _extract_with_scrfd(self, bgr_img: np.ndarray, *, imgsz: Optional[int] = None):
         self._frame_idx += 1
-        # prescan throttle for both SCRFD and insight_app backends
-        if self._fast_prescan:
-            period = max(1, int(getattr(self, "_prescan_period", 3)))
-            if not (
-                self._prescan_escalate
-                or ((self._frame_idx + self._prescan_rr) % period) == 0
-            ):
-                return []
+        # Do not gate the whole pre-scan extractor here. prescan_rot_probe_period
+        # is only a rotated-fallback cadence; the caller-level fd9 gate is the
+        # only deliberate whole-sample skip. Returning [] here makes a skipped
+        # detector pass indistinguishable from “no face”, which corrupts the
+        # fd9 streak and causes delayed/missed target re-entry.
         if self.scrfd is not None:
             return self._extract_with_scrfd_raw(bgr_img, imgsz=imgsz)
         if self.insight_app is not None:
@@ -2194,9 +2192,14 @@ class FaceEmbedder:
         # speed-up: during a no-face streak, use a smaller first-pass size
         if self._no_face_streak >= 3:
             dyn = min(dyn, self.fast_no_face_imgsz)
-        # in fast pre-scan, cap upright pass to probe size for empty scenes
+        # In fast pre-scan, cap the upright pass to the probe size. If the
+        # pre-scan reader already decoded/downscaled to a smaller frame, avoid
+        # upscaling it back to 512+ just for SCRFD input. Upscaling cannot add
+        # face detail, but it increases detector cost quadratically.
         if self._fast_prescan:
             dyn = min(dyn, int(getattr(self, "_prescan_probe_imgsz", 384)))
+            if bool(getattr(self, "_prescan_no_upscale_det", True)):
+                dyn = min(dyn, _round32(max(H0, W0)))
         dyn = _round32(max(320, dyn))
         L = max(H0, W0)
         heavy_cap = max(int(getattr(self, "_heavy_cap", 2048)), dyn)  # optional safety cap

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -491,7 +491,8 @@ class SessionConfig:
     prescan_fd_exit: float = 0.52          # ArcFace dist to EXIT  (hysteresis)
     prescan_add_cooldown_samples: int = 5  # add at most every N prescan samples
     prescan_rot_probe_period: int = 3      # probe rotations every N samples; upright pass still runs every sample
-    prescan_probe_imgsz: int = 512         # slightly stronger probe
+    prescan_probe_imgsz: int = 512         # max SCRFD 0° probe size during pre-scan
+    prescan_no_upscale_det: bool = True    # don't upscale low-res pre-scan frames only to run SCRFD
     prescan_probe_conf: float = 0.03
     prescan_heavy_90: int = 1536
     prescan_heavy_180: int = 1280
@@ -725,6 +726,7 @@ class Processor(QtCore.QObject):
             "prescan_add_cooldown_samples",
             "prescan_rot_probe_period",
             "prescan_probe_imgsz",
+            "prescan_no_upscale_det",
             "prescan_probe_conf",
             "prescan_heavy_90",
             "prescan_heavy_180",
@@ -1091,6 +1093,7 @@ class Processor(QtCore.QObject):
                     ("_probe_conf", "prescan_probe_conf", float, 0.03),
                     ("_prescan_period", "prescan_rot_probe_period", int, 3),
                     ("_prescan_probe_imgsz", "prescan_probe_imgsz", int, 512),
+                    ("_prescan_no_upscale_det", "prescan_no_upscale_det", bool, True),
                     ("_high_90", "prescan_heavy_90", int, 1536),
                     ("_high_180", "prescan_heavy_180", int, 1280),
                 ):
@@ -9634,8 +9637,16 @@ class MainWindow(QtWidgets.QMainWindow):
         self.spin_prescan_probe_imgsz.setRange(0, 4096)
         self.spin_prescan_probe_imgsz.setSingleStep(32)
         self.spin_prescan_probe_imgsz.setValue(int(getattr(self.cfg, "prescan_probe_imgsz", 512)))
-        self.spin_prescan_probe_imgsz.setToolTip("int: prescan_probe_imgsz (0 = detector default)")
+        self.spin_prescan_probe_imgsz.setToolTip("int: prescan_probe_imgsz; maximum SCRFD 0° probe size during pre-scan")
         self.spin_prescan_probe_imgsz.valueChanged.connect(self._on_ui_change)
+
+        self.chk_prescan_no_upscale_det = QtWidgets.QCheckBox()
+        self.chk_prescan_no_upscale_det.setChecked(bool(getattr(self.cfg, "prescan_no_upscale_det", True)))
+        self.chk_prescan_no_upscale_det.setToolTip(
+            "bool: prescan_no_upscale_det. Avoid upscaling low-res pre-scan frames before SCRFD; "
+            "faster and usually equivalent when prescan_decode_max_w/prescan_max_width already reduced the frame."
+        )
+        self.chk_prescan_no_upscale_det.stateChanged.connect(self._on_ui_change)
 
         self.spin_prescan_probe_conf = QtWidgets.QDoubleSpinBox()
         self.spin_prescan_probe_conf.setDecimals(3)
@@ -10061,6 +10072,7 @@ class MainWindow(QtWidgets.QMainWindow):
             ("Pre-scan replace margin", self.spin_prescan_margin),
             ("Pre-scan rotated probe period", self.spin_prescan_rot_probe_period),
             ("Pre-scan probe imgsz", self.spin_prescan_probe_imgsz),
+            ("Pre-scan no detector upscale", self.chk_prescan_no_upscale_det),
             ("Pre-scan probe conf", self.spin_prescan_probe_conf),
             ("Pre-scan heavy 90° imgsz", self.spin_prescan_heavy_90),
             ("Pre-scan heavy 180° imgsz", self.spin_prescan_heavy_180),
@@ -11258,6 +11270,7 @@ class MainWindow(QtWidgets.QMainWindow):
             "prescan_add_cooldown_samples",
             "prescan_rot_probe_period",
             "prescan_probe_imgsz",
+            "prescan_no_upscale_det",
             "prescan_probe_conf",
             "prescan_heavy_90",
             "prescan_heavy_180",
@@ -11443,6 +11456,7 @@ class MainWindow(QtWidgets.QMainWindow):
             prescan_add_cooldown_samples=int(self.spin_prescan_add_cooldown.value()) if hasattr(self, "spin_prescan_add_cooldown") else 5,
             prescan_rot_probe_period=int(self.spin_prescan_rot_probe_period.value()) if hasattr(self, "spin_prescan_rot_probe_period") else int(getattr(self.cfg, "prescan_rot_probe_period", 3)),
             prescan_probe_imgsz=int(self.spin_prescan_probe_imgsz.value()) if hasattr(self, "spin_prescan_probe_imgsz") else int(getattr(self.cfg, "prescan_probe_imgsz", 512)),
+            prescan_no_upscale_det=bool(self.chk_prescan_no_upscale_det.isChecked()) if hasattr(self, "chk_prescan_no_upscale_det") else bool(getattr(self.cfg, "prescan_no_upscale_det", True)),
             prescan_probe_conf=float(self.spin_prescan_probe_conf.value()) if hasattr(self, "spin_prescan_probe_conf") else float(getattr(self.cfg, "prescan_probe_conf", 0.03)),
             prescan_heavy_90=int(self.spin_prescan_heavy_90.value()) if hasattr(self, "spin_prescan_heavy_90") else int(getattr(self.cfg, "prescan_heavy_90", 1536)),
             prescan_heavy_180=int(self.spin_prescan_heavy_180.value()) if hasattr(self, "spin_prescan_heavy_180") else int(getattr(self.cfg, "prescan_heavy_180", 1280)),
@@ -11861,6 +11875,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self.spin_prescan_rot_probe_period.setValue(int(getattr(cfg, 'prescan_rot_probe_period', 3)))
         if hasattr(self, 'spin_prescan_probe_imgsz'):
             self.spin_prescan_probe_imgsz.setValue(int(getattr(cfg, 'prescan_probe_imgsz', 512)))
+        if hasattr(self, 'chk_prescan_no_upscale_det'):
+            self.chk_prescan_no_upscale_det.setChecked(bool(getattr(cfg, 'prescan_no_upscale_det', True)))
         if hasattr(self, 'spin_prescan_probe_conf'):
             self.spin_prescan_probe_conf.setValue(float(getattr(cfg, 'prescan_probe_conf', 0.03)))
         if hasattr(self, 'spin_prescan_heavy_90'):
@@ -12990,6 +13006,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self.spin_prescan_rot_probe_period.setValue(int(s.value("prescan_rot_probe_period", getattr(self.cfg, "prescan_rot_probe_period", 3))))
         if hasattr(self, 'spin_prescan_probe_imgsz'):
             self.spin_prescan_probe_imgsz.setValue(int(s.value("prescan_probe_imgsz", getattr(self.cfg, "prescan_probe_imgsz", 512))))
+        if hasattr(self, 'chk_prescan_no_upscale_det'):
+            self.chk_prescan_no_upscale_det.setChecked(s.value("prescan_no_upscale_det", getattr(self.cfg, "prescan_no_upscale_det", True), type=bool))
         if hasattr(self, 'spin_prescan_probe_conf'):
             self.spin_prescan_probe_conf.setValue(float(s.value("prescan_probe_conf", getattr(self.cfg, "prescan_probe_conf", 0.03))))
         if hasattr(self, 'spin_prescan_heavy_90'):

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -11876,7 +11876,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if hasattr(self, 'spin_prescan_probe_imgsz'):
             self.spin_prescan_probe_imgsz.setValue(int(getattr(cfg, 'prescan_probe_imgsz', 512)))
         if hasattr(self, 'chk_prescan_no_upscale_det'):
-            self.chk_prescan_no_upscale_det.setChecked(bool(getattr(cfg, 'prescan_no_upscale_det', True)))
+            _prescan_no_upscale_det = bool(getattr(cfg, 'prescan_no_upscale_det', True))
+            self.chk_prescan_no_upscale_det.setChecked(_prescan_no_upscale_det)
+            self.cfg.prescan_no_upscale_det = _prescan_no_upscale_det
         if hasattr(self, 'spin_prescan_probe_conf'):
             self.spin_prescan_probe_conf.setValue(float(getattr(cfg, 'prescan_probe_conf', 0.03)))
         if hasattr(self, 'spin_prescan_heavy_90'):
@@ -13007,7 +13009,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if hasattr(self, 'spin_prescan_probe_imgsz'):
             self.spin_prescan_probe_imgsz.setValue(int(s.value("prescan_probe_imgsz", getattr(self.cfg, "prescan_probe_imgsz", 512))))
         if hasattr(self, 'chk_prescan_no_upscale_det'):
-            self.chk_prescan_no_upscale_det.setChecked(s.value("prescan_no_upscale_det", getattr(self.cfg, "prescan_no_upscale_det", True), type=bool))
+            _prescan_no_upscale_det = bool(s.value("prescan_no_upscale_det", getattr(self.cfg, "prescan_no_upscale_det", True), type=bool))
+            self.chk_prescan_no_upscale_det.setChecked(_prescan_no_upscale_det)
+            self.cfg.prescan_no_upscale_det = _prescan_no_upscale_det
         if hasattr(self, 'spin_prescan_probe_conf'):
             self.spin_prescan_probe_conf.setValue(float(s.value("prescan_probe_conf", getattr(self.cfg, "prescan_probe_conf", 0.03))))
         if hasattr(self, 'spin_prescan_heavy_90'):


### PR DESCRIPTION
This PR applies the corrected prescan speed patch from the provided file.

## Changes
- update prescan/embedder flow adjustments in person_capture/face_embedder.py
- update related GUI prescan behavior in person_capture/gui_app.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Pre-scan no detector upscale" GUI checkbox to control whether low-resolution pre-scan frames are upscaled before detection, with persistent configuration.

* **Bug Fixes**
  * Fixed pre-scan skip behavior that could be mistaken for "no face," preventing corruption of face detection/tracking streaks.

* **Performance**
  * Clamped pre-scan detector input sizing to avoid unnecessary upscaling, reducing detection compute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->