### PR TITLE
Add update guard for git checkout path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,9 @@ Thumbs.db
 # Runtime output can be large and must survive updater operations.
 /person_capture/output/
 /person_capture/out/
+
+# Runtime output variants created by ad-hoc GUI runs.
+/output*/
+/person_capture/output*/
+/prescan_cache/
+/solidpreset[0-9]*.json

--- a/person_capture/updater.py
+++ b/person_capture/updater.py
@@ -398,10 +398,13 @@ def _discard_pending_zip_update(repo: Path, flag: Optional[Path] = None, staged:
             staged = repo / "update_staged"
         # Only delete the updater-owned staging directory under the install root.
         repo_resolved = repo.resolve()
+        expected_raw = repo_resolved / "update_staged"
+        if expected_raw.is_symlink() or staged.is_symlink():
+            return
         staged_resolved = staged.resolve(strict=False)
-        expected = (repo_resolved / "update_staged").resolve(strict=False)
-        if staged_resolved == expected and not staged_resolved.is_symlink():
-            shutil.rmtree(staged_resolved, ignore_errors=True)
+        expected_resolved = expected_raw.resolve(strict=False)
+        if staged_resolved == expected_resolved:
+            shutil.rmtree(expected_raw, ignore_errors=True)
     except Exception:
         pass
 

--- a/person_capture/updater.py
+++ b/person_capture/updater.py
@@ -97,7 +97,11 @@ def _repo_root_for(path: Path) -> Path:
     return path
 
 def is_git_repo(repo: Path) -> bool:
-    return (repo / ".git").exists() and bool(_which("git"))
+    return is_git_checkout(repo) and bool(_which("git"))
+
+
+def is_git_checkout(repo: Path) -> bool:
+    return (repo / ".git").exists()
 
 def ensure_https_remote(repo: Path) -> None:
     try:
@@ -346,7 +350,7 @@ def stage_zip_update(repo: Path, branch: Optional[str] = None) -> Tuple[bool, st
     Download and stage the latest zipball of branch to repo/update_staged.
     Returns (ok, msg, staged_flag_file).
     """
-    if is_git_repo(repo):
+    if is_git_checkout(repo):
         return False, "Zip update disabled inside git checkout; use git fast-forward update instead.", None
     try:
         branch = branch or _default_branch()
@@ -512,7 +516,7 @@ def apply_staged_update(repo: Path) -> Tuple[bool, str]:
         flag = repo / "update_pending.json"
         if not flag.exists():
             return False, "no pending update"
-        if is_git_repo(repo):
+        if is_git_checkout(repo):
             _discard_pending_zip_update(repo, flag=flag)
             return False, "ignored pending zip update inside git checkout"
         with open(flag, "r", encoding="utf-8") as f:
@@ -709,7 +713,11 @@ class UpdateManager(QtCore.QObject if QtCore else object):
                     return
                 self.info.emit("Checking for updates…")
                 # path 1: git
-                if is_git_repo(self.repo):
+                if is_git_checkout(self.repo):
+                    if not is_git_repo(self.repo):
+                        s.setValue("update_last_check_t", _now()); s.sync()
+                        self.info.emit("Update check skipped: git checkout detected but git executable is unavailable.")
+                        return
                     need, local, remote = _git_need_updates(self.repo)
                     s.setValue("update_last_check_t", _now()); s.sync()
                     if need:
@@ -746,7 +754,12 @@ class UpdateManager(QtCore.QObject if QtCore else object):
             return
         def _run():
             try:
-                if is_git_repo(self.repo):
+                if is_git_checkout(self.repo):
+                    if not is_git_repo(self.repo):
+                        self.updateFailed.emit(
+                            "Git checkout detected but git executable is unavailable; cannot run fast-forward update."
+                        )
+                        return
                     if not prefer_git:
                         self.updateFailed.emit(
                             "Zip update disabled inside git checkout; use git fast-forward update instead."

--- a/person_capture/updater.py
+++ b/person_capture/updater.py
@@ -346,6 +346,8 @@ def stage_zip_update(repo: Path, branch: Optional[str] = None) -> Tuple[bool, st
     Download and stage the latest zipball of branch to repo/update_staged.
     Returns (ok, msg, staged_flag_file).
     """
+    if is_git_repo(repo):
+        return False, "Zip update disabled inside git checkout; use git fast-forward update instead.", None
     try:
         branch = branch or _default_branch()
         sha = _latest_commit_sha(branch)
@@ -381,6 +383,28 @@ def stage_zip_update(repo: Path, branch: Optional[str] = None) -> Tuple[bool, st
         return True, f"Staged {sha[:7]} to {stage}", str(flag)
     except Exception as e:
         return False, f"stage error: {e}", None
+
+def _discard_pending_zip_update(repo: Path, flag: Optional[Path] = None, staged: Optional[Path] = None) -> None:
+    """Remove a staged zip update without touching source files."""
+    try:
+        if flag is None:
+            flag = repo / "update_pending.json"
+        if flag.exists():
+            flag.unlink()
+    except Exception:
+        pass
+    try:
+        if staged is None:
+            staged = repo / "update_staged"
+        # Only delete the updater-owned staging directory under the install root.
+        repo_resolved = repo.resolve()
+        staged_resolved = staged.resolve(strict=False)
+        expected = (repo_resolved / "update_staged").resolve(strict=False)
+        if staged_resolved == expected and not staged_resolved.is_symlink():
+            shutil.rmtree(staged_resolved, ignore_errors=True)
+    except Exception:
+        pass
+
 
 def _remove_path_for_update_replace(path: Path) -> None:
     """Remove a path that is about to be replaced by an update payload."""
@@ -485,6 +509,9 @@ def apply_staged_update(repo: Path) -> Tuple[bool, str]:
         flag = repo / "update_pending.json"
         if not flag.exists():
             return False, "no pending update"
+        if is_git_repo(repo):
+            _discard_pending_zip_update(repo, flag=flag)
+            return False, "ignored pending zip update inside git checkout"
         with open(flag, "r", encoding="utf-8") as f:
             info = json.load(f)
         sha_applied = str(info.get("sha") or "")
@@ -716,24 +743,20 @@ class UpdateManager(QtCore.QObject if QtCore else object):
             return
         def _run():
             try:
-                if prefer_git and is_git_repo(self.repo):
+                if is_git_repo(self.repo):
+                    if not prefer_git:
+                        self.updateFailed.emit(
+                            "Zip update disabled inside git checkout; use git fast-forward update instead."
+                        )
+                        return
                     self.progress.emit("Updating via git…")
                     ok, msg = git_update(self.repo, autostash=False)
                     if ok:
                         self.updated.emit(msg)
-                        return
                     else:
-                        lower_msg = msg.lower()
-                        if (
-                            "update blocked:" in lower_msg
-                            or "unresolved merge conflicts" in lower_msg
-                            or "operation already in progress" in lower_msg
-                            or "tracked local changes present" in lower_msg
-                        ):
-                            self.updateFailed.emit(msg)
-                            return
-                        # Fall back to zip if git failed (e.g., conflicts)
-                        self.info.emit(f"git update failed, will try zip: {msg}")
+                        self.updateFailed.emit(msg)
+                    return
+
                 self.progress.emit("Staging zip update…")
                 ok, msg, flag = stage_zip_update(self.repo, branch=branch or _default_branch())
                 if ok:

--- a/person_capture/updater.py
+++ b/person_capture/updater.py
@@ -715,7 +715,8 @@ class UpdateManager(QtCore.QObject if QtCore else object):
                 # path 1: git
                 if is_git_checkout(self.repo):
                     if not is_git_repo(self.repo):
-                        s.setValue("update_last_check_t", _now()); s.sync()
+                        s.setValue("update_last_check_t", _now())
+                        s.sync()
                         self.info.emit("Update check skipped: git checkout detected but git executable is unavailable.")
                         return
                     need, local, remote = _git_need_updates(self.repo)


### PR DESCRIPTION
## Summary
- apply the provided checkout update guard patch
- guard git checkout update flow in updater logic
- update ignore rules related to update artifacts

## Notes
- Changes were applied from .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zip-based update staging and apply are disabled when running from a repository checkout; any pending staged update artifacts are detected and removed to prevent partial or confusing updates.
  * Update checks and install flows no longer fall back to zip for repository checkouts and will surface failures directly.

* **Chores**
  * Expanded ignore patterns to exclude extra runtime/output directories, prescan cache, temporary artifacts, and numbered preset files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->