### PR TITLE
Fix top-heavy smart portrait crop placement

### DIFF
--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -8179,8 +8179,8 @@ class Processor(QtCore.QObject):
                             prof,
                         )
                     )
-                except Exception:
-                    pass
+                except (TypeError, ValueError):
+                    continue
         ax1, ay1, ax2, ay2 = anchor_crop
         acx = 0.5 * (ax1 + ax2)
         acy = 0.5 * (ay1 + ay2)

--- a/person_capture/gui_app.py
+++ b/person_capture/gui_app.py
@@ -8163,6 +8163,24 @@ class Processor(QtCore.QObject):
             offsets = [(float(dx), float(dy)) for dx in dx_vals for dy in dy_vals]
 
         candidate_set = {seed_crop, anchor_crop}
+        if face is not None and prof in {"close", "portrait_close", "upper", "base"}:
+            # Add a deterministic downward-settled candidate. The saliency grid
+            # below may legitimately move left/right, but portrait placement must
+            # not waste vertical pixels above the detected head when the same
+            # fixed-size crop can include more body/shoulder context below.
+            for base_cand in (seed_crop, anchor_crop):
+                try:
+                    candidate_set.add(
+                        self._prefer_lower_face_crop_y(
+                            base_cand,
+                            face,
+                            protect,
+                            bounds,
+                            prof,
+                        )
+                    )
+                except Exception:
+                    pass
         ax1, ay1, ax2, ay2 = anchor_crop
         acx = 0.5 * (ax1 + ax2)
         acy = 0.5 * (ay1 + ay2)
@@ -8222,6 +8240,42 @@ class Processor(QtCore.QObject):
                 right = max(0.0, x2 - fx2)
                 if desired_side > 0:
                     score += 0.40 * max(0.0, desired_side - min(left, right)) / desired_side
+
+                if prof in {"close", "portrait_close", "upper", "base"}:
+                    # Vertical composition invariant for face crops: excess
+                    # headroom is worse than using the same fixed-ratio crop to
+                    # keep more body/shoulders below the face. Use the generated
+                    # head proxy as a top hint, but cap over-expanded proxies so
+                    # close-ups are not forced to reserve unrealistic hair space.
+                    top_guard = fy1
+                    if protect is not None:
+                        try:
+                            _, py1, _, _ = [float(v) for v in protect]
+                            proxy_top = min(py1, fy1)
+                            proxy_floor = fy1 - 0.45 * fh
+                            top_guard = max(proxy_floor, proxy_top)
+                        except Exception:
+                            top_guard = fy1
+                    top_margin_frac = max(0.0, top_guard - y1) / ch
+                    headroom_cap = max(0.02, min(0.30, float(getattr(cfg, "crop_top_headroom_max_frac", 0.15))))
+                    if prof == "upper":
+                        headroom_cap = min(headroom_cap, 0.09)
+                    elif prof == "portrait_close":
+                        headroom_cap = min(headroom_cap, 0.10)
+                    elif prof == "close":
+                        headroom_cap = min(headroom_cap, 0.12)
+                    score += 1.35 * max(0.0, top_margin_frac - headroom_cap) / max(0.04, headroom_cap)
+
+                    bottom_face_heights = max(0.0, y2 - fy2) / fh
+                    want_bottom = max(0.0, float(getattr(cfg, "crop_bottom_min_face_heights", 1.5)))
+                    if prof == "upper":
+                        want_bottom = max(want_bottom, 2.25)
+                    elif prof == "portrait_close":
+                        want_bottom = max(want_bottom, 1.75)
+                    elif prof == "close":
+                        want_bottom = max(want_bottom, 1.20)
+                    score += 0.18 * max(0.0, want_bottom - bottom_face_heights)
+
                 if prof == "wide_context":
                     # Wide/context should actually use horizontal context.
                     side_face_heights = min(left, right) / max(1.0, fh)


### PR DESCRIPTION
## Summary
Fixes portrait/upper smart-crop vertical bias that favored excess headroom over torso context.

## Changes
- Add deterministic downward-settled candidates via _prefer_lower_face_crop_y() even when smart-crop scoring is enabled.
- Add explicit portrait-profile vertical penalties in _smart_crop_box() for:
  - excessive top headroom above face/head proxy
  - insufficient bottom context beneath the face
- Keep existing saliency/face-center behavior while enforcing portrait composition invariants.

## Why
The old lower-face pass corrected this but was bypassed under smart_crop_enable=True. Smart-crop scoring also lacked an explicit excess-headroom penalty and deterministic lower candidate, allowing top-heavy crops.

## Validation
- Static diff inspection confirms changes are isolated to person_capture/gui_app.py smart-crop candidate generation and scoring.
- No repository tests were run per repo instruction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced portrait and close-up cropping: adds a deterministic option that favors slightly lower framing, improves vertical composition with smarter headroom control, reduces excessive top space for close/upper portraits, and boosts bottom-face coverage to better balance face placement for more pleasing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->